### PR TITLE
feature: support dir with regex to scan files

### DIFF
--- a/gocovmerge.go
+++ b/gocovmerge.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
+	"regexp"
 	"sort"
 
 	"golang.org/x/tools/cover"
@@ -93,6 +95,9 @@ func dumpProfiles(profiles []*cover.Profile, out io.Writer) {
 }
 
 func main() {
+	dir := flag.String("dir", "", "the dir will scan")
+	pattern := flag.String("pattern", "", "cover pattern to match")
+
 	flag.Parse()
 
 	var merged []*cover.Profile
@@ -104,6 +109,41 @@ func main() {
 		}
 		for _, p := range profiles {
 			merged = addProfile(merged, p)
+		}
+	}
+
+	if *dir != "" && *pattern != "" {
+		re, err := regexp.Compile(*pattern)
+		if err != nil {
+			panic(err)
+		}
+
+		var files []string
+
+		filepath.Walk(*dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			if re.MatchString(path) {
+				files = append(files, path)
+			}
+
+			return nil
+		})
+
+		for _, file := range files {
+			profiles, err := cover.ParseProfiles(file)
+			if err != nil {
+				log.Fatalf("failed to parse profiles: %v", err)
+			}
+			for _, p := range profiles {
+				merged = addProfile(merged, p)
+			}
 		}
 	}
 


### PR DESCRIPTION
Hello. @wadey 

just add the CLI args --dir and --pattern to allow gocovmerge to scan files in specified dir recursively 
as the following:

````bash
	gocovmerge -dir tests -pattern "\.cover\.out" > ${CURRENT_DIR}/tests/cover.out
````